### PR TITLE
Home Padrino Creado con lista de Encargados

### DIFF
--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -10,6 +10,7 @@ import { PerfilNinoComponent } from './paginas/perfil-nino/perfil-nino.component
 import { EditarEncargadoComponent } from './paginas/editar-encargado/editar-encargado.component';
 import { EditarNinoComponent } from './paginas/editar-nino/editar-nino.component';
 import { EditarPadrinoComponent } from './paginas/editar-padrino/editar-padrino.component';
+import { HomePadrinoComponent } from './paginas/home-padrino/home-padrino.component';
 
 export const routes: Routes = [
     {path:'', component: InicioComponent, title:"Pagina de Inicio"},
@@ -21,6 +22,7 @@ export const routes: Routes = [
     {path:'perfil-nino/:ci', component: PerfilNinoComponent, title:'Nino'},
     {path:'editar-perfil-encargado/:id', component: EditarEncargadoComponent, title: "Editar Encargado"},
     {path:'editar-perfil-padrino/:id', component: EditarPadrinoComponent, title: 'Padrino'},
+    {path:'home-padrino/:id', component: HomePadrinoComponent, title:'Pagina Padrino'},
     {path:'editar-nino/:id', component: EditarNinoComponent, title:'Nino'},
     {path:'login', component: LoginComponent, title: "Log in"},
     {path:'**', redirectTo:'', pathMatch: 'full'}

--- a/src/app/paginas/crear-padrino/crear-padrino.component.ts
+++ b/src/app/paginas/crear-padrino/crear-padrino.component.ts
@@ -31,7 +31,7 @@ export class CrearPadrinoComponent {
         else{
           console.log('Padrino registrado con éxito!', response);
           alert('Padrino registrado con éxito!');
-          this.router.navigate([`/perfil-padrino/${response.id}`]);
+          this.router.navigate([`/home-padrino/${response.id}`]);
         }
       },
       error: (err) => {

--- a/src/app/paginas/home-padrino/home-padrino.component.html
+++ b/src/app/paginas/home-padrino/home-padrino.component.html
@@ -1,0 +1,29 @@
+<div class="home-padrino-container" *ngIf="padrino">
+    <div class="home-padrino-header">
+      <img src="imgs/hopematch-logo.png" alt="HopeMatch Logo" class="logo">
+      <nav class="perfil-nav">
+        <a (click)="irPerfil()" style="color: #e65c4f; cursor: pointer;">Ver Perfil</a>
+        <a routerLink="#" style="color: #e65c4f;">Cerrar Sesión</a>
+      </nav>
+    </div>
+  
+    <div class="saludo">
+      <h2>Hola {{ padrino.nombre }}, ¿qué quieres hacer hoy?</h2>
+    </div>
+  
+    <div class="encargados-lista">
+      <div class="encargado-card" *ngFor="let encargado of encargados">
+        <div class="encargado-info">
+          <div class="encargado-foto">
+            <img [src]="encargado.foto" alt="Foto del Encargado" />
+          </div>
+          <div class="encargado-detalles">
+            <h3>{{ encargado.nombre }}</h3>
+            <p>{{ encargado.direccion_hogar }}</p>
+            <button class="btn-ver-hogar" (click)="verHogar(encargado.id)">Ver Hogar</button>
+            <button class="btn-donar">Donar</button>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/src/app/paginas/home-padrino/home-padrino.component.scss
+++ b/src/app/paginas/home-padrino/home-padrino.component.scss
@@ -1,0 +1,112 @@
+.home-padrino-container {
+    display: flex;
+    flex-direction: column;
+    padding: 2rem;
+    background-color: #f6f6f6;
+    height: 92vh;
+    padding: 15px;
+  }
+  
+  .home-padrino-header {
+    display: flex;
+      justify-content: space-between;
+      align-items: center;
+      padding: 0;
+  
+      .logo {
+        max-width: 80px;
+      }
+  
+      .perfil-nav {
+        display: flex;
+        gap: 2rem;
+  
+        a {
+          text-decoration: none;
+          font-size: 1rem;
+          color: #333;
+        }
+      }
+  }
+  
+  .saludo {
+    margin-top: 1.5rem;
+    text-align: center;
+    font-size: 1.8rem;
+    color: #e65c4f;
+  }
+  
+  .encargados-lista {
+      flex: 1;
+      background-color: #fff;
+      padding: 2rem;
+      border-radius: 10px;
+      box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+      max-height: 450px;
+      overflow-y: auto;
+      height: 100vh;
+      align-self: flex-end;
+      width: 50%;
+  }
+  
+  .encargado-card {
+    display: flex;
+    flex-direction: column;
+    background-color: #fff;
+    padding: 20px;
+    border-radius: 10px;
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
+    width: 100%;
+    max-width: 650px;
+    margin: 0 auto;
+  }
+  
+  .encargado-info {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+  }
+  
+  .encargado-foto {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    overflow: hidden;
+  
+    img {
+      width: 100%;
+      height: 100%;
+      object-fit: cover;
+    }
+  }
+  
+  .encargado-detalles {
+    flex: 1;
+  }
+  
+  .encargado-detalles h3 {
+    font-size: 1.5rem;
+    margin: 0;
+    color: #333;
+  }
+  
+  .encargado-detalles p {
+    font-size: 1rem;
+    margin: 0.5rem 0;
+    color: #555;
+  }
+  
+  .btn-ver-hogar, .btn-donar {
+    padding: 0.75rem 1.5rem;
+    background-color: #e65c4f;
+    color: white;
+    margin-top: 1rem;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 1rem;
+  }
+  
+  .btn-ver-hogar {
+    margin-right: 10px;
+  }

--- a/src/app/paginas/home-padrino/home-padrino.component.spec.ts
+++ b/src/app/paginas/home-padrino/home-padrino.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HomePadrinoComponent } from './home-padrino.component';
+
+describe('HomePadrinoComponent', () => {
+  let component: HomePadrinoComponent;
+  let fixture: ComponentFixture<HomePadrinoComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HomePadrinoComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(HomePadrinoComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/paginas/home-padrino/home-padrino.component.ts
+++ b/src/app/paginas/home-padrino/home-padrino.component.ts
@@ -1,0 +1,59 @@
+import { CommonModule } from '@angular/common';
+import { Component, OnInit } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { PadrinoService } from '../../servicios/padrino.service';
+import { EncargadoService } from '../../servicios/encargado.service';
+
+@Component({
+  selector: 'app-home-padrino',
+  imports: [RouterLink, CommonModule, FormsModule],
+  templateUrl: './home-padrino.component.html',
+  styleUrl: './home-padrino.component.scss'
+})
+export class HomePadrinoComponent implements OnInit{
+
+  padrino: any = null;
+  encargados: any[] = [];
+
+  constructor(private route:ActivatedRoute, 
+                private padrinoService: PadrinoService, 
+                private router: Router,
+                private encargadoService: EncargadoService){}
+  
+                
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id');
+
+    if (id) {
+      this.padrinoService.getPadrinoById(+id).subscribe({
+        next: (data) => {
+          this.padrino = data;
+        },
+        error: (err) => {
+          console.error('Error al obtener encargado:', err);
+        }
+      });
+    }
+
+    this.obtenerEncargados();
+  }
+
+  obtenerEncargados(): void {
+    this.encargadoService.getEncargados().subscribe(
+      data => this.encargados = data,
+      error => console.log(error),
+      () => console.log('Encargados Obtenidos Exitosamente!'),);
+      console.log("this.encargados")
+  }
+
+  irPerfil(): void{
+    if (this.padrino) {
+      this.router.navigate([`/perfil-padrino/${this.padrino.id}`]);
+    }
+  }
+
+  verHogar(idHogar: number): void {
+    this.router.navigate([`/perfil-encargado/${idHogar}`]);
+  }
+}

--- a/src/app/paginas/login/login.component.ts
+++ b/src/app/paginas/login/login.component.ts
@@ -25,7 +25,7 @@ export class LoginComponent {
           this.router.navigate([`/perfil-encargado/${parsedResponse.id}`]);
         }
         if(parsedResponse.userType == "Padrino"){
-          this.router.navigate([`/perfil-padrino/${parsedResponse.id}`]);
+          this.router.navigate([`/home-padrino/${parsedResponse.id}`]);
         }
       },
       error: (err) => {

--- a/src/app/paginas/perfil-padrino/perfil-padrino.component.html
+++ b/src/app/paginas/perfil-padrino/perfil-padrino.component.html
@@ -1,28 +1,29 @@
 <div class="perfil-container" *ngIf="padrino">
-    <div class="perfil-header">
-      <img src="imgs/hopematch-logo.png" alt="HopeMatch Logo" class="logo">
-      <nav class="perfil-nav">
-        <a routerLink="#" style="color: #e65c4f;">Cerrar Sesión</a>
-      </nav>
-    </div>
-  
-    <div class="perfil-content">
-      <div class="perfil-info">
-        <div class="perfil-foto">
-          <img [src]="padrino.foto" alt="Foto del Encargado" />
-        </div>
-        <div class="perfil-detalles">
-          <h2>Mi Perfil</h2>
-          <h3>{{ padrino.nombre }}</h3>
-          <p><strong>E-mail:</strong> {{ padrino.email }}</p>
-          <p><strong>Celular:</strong> {{ padrino.celular }}</p>
-          <button class="btn-editar" (click)="irEditarPerfil()">Editar Datos</button>
-        </div>
+  <div class="perfil-header">
+    <img src="imgs/hopematch-logo.png" alt="HopeMatch Logo" class="logo">
+    <nav class="perfil-nav">
+      <a (click)="VolverAHome()" style="color: #e65c4f; cursor: pointer;">Volver a Home</a>
+      <a routerLink="#" style="color: #e65c4f;">Cerrar Sesión</a>
+    </nav>
+  </div>
+
+  <div class="perfil-content">
+    <div class="perfil-info">
+      <div class="perfil-foto">
+        <img [src]="padrino.foto" alt="Foto del Encargado" />
       </div>
-  
+      <div class="perfil-detalles">
+        <h2>Mi Perfil</h2>
+        <h3>{{ padrino.nombre }}</h3>
+        <p><strong>E-mail:</strong> {{ padrino.email }}</p>
+        <p><strong>Celular:</strong> {{ padrino.celular }}</p>
+        <button class="btn-editar" (click)="irEditarPerfil()">Editar Datos</button>
+      </div>
     </div>
+
   </div>
-  
-  <div *ngIf="!padrino">
-    <p>Cargando datos...</p>
-  </div>
+</div>
+
+<div *ngIf="!padrino">
+  <p>Cargando datos...</p>
+</div>

--- a/src/app/paginas/perfil-padrino/perfil-padrino.component.ts
+++ b/src/app/paginas/perfil-padrino/perfil-padrino.component.ts
@@ -34,4 +34,10 @@ export class PerfilPadrinoComponent implements OnInit{
       this.router.navigate([`/editar-perfil-padrino/${this.padrino.id}`]);
     }
   }
+
+  VolverAHome():void{
+    if (this.padrino) {
+      this.router.navigate([`/home-padrino/${this.padrino.id}`]);
+    }
+  }
 }


### PR DESCRIPTION
Nuevo componente, home-padrino, donde se muestra la lista de los encargados registrados.
Tambien hay un enlace de Ver Perfil que se va al perfil del Padrino.
Y si apretamos el boton de Ver Hogar se va al Perfil del hogar (por ahora, debemos crear un componente donde muestre solo datos generales del hogar y no el perfil con todos los niños).
Esta vista se accede desde el inicio de sesion y desde la creacion de un nuevo padrino.