### PR TITLE
HM3-05 Subir fotos progreso

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9558,6 +9558,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
       "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       }

--- a/src/app/config/constants.ts
+++ b/src/app/config/constants.ts
@@ -38,6 +38,43 @@ export const TEXTOS = {
 
     // ERROR MESSAGES
     defaultError: 'Ha ocurrido un error, por favor intente de nuevo.',
-    logInError: ''
+    logInError: '',
+
+    // DONATIONS
+    donacionesRecibidas: 'Donaciones Recibidas',
+    noDonaciones: 'No hay donaciones registradas.',
+    agregarComentario: 'Agregar Comentario',
+    comentarioEnviado: 'Comentario enviado',
+    fotoComprobanteEnviada: 'Foto Comprobante enviada',
+    agregarFotoComprobante: 'Agregar Foto Comprobante',
+    agregarFotosProgreso: 'Agregar Fotos Progreso',
+    fotoComprobante: 'Foto comprobante:',
+    fotosProgreso: 'Fotos de progreso:',
+    padrino: 'Padrino: ',
+    necesidades: 'Necesidades: ',
+    
+    // MODALS
+    modalAgregarComentario: 'Agregar Comentario',
+    placeholderComentario: 'Escribe tu comentario...',
+    modalAgregarFoto: 'Agregar Foto Comprobante',
+    placeholderFotoUrl: 'Ingresa la URL de la foto...',
+    modalAgregarFotosProgreso: 'Agregar Fotos de Progreso',
+    fotosAEnviar: 'Fotos a enviar',
+    maxFotosAlerta: 'Has alcanzado el límite máximo de 8 fotos',
+    
+    // DONATION BUTTONS
+    cancelar: 'Cancelar',
+    enviar: 'Enviar',
+    agregar: 'Agregar',
+    
+    // MESSAGES
+    comentarioExito: '¡Comentario enviado con éxito!',
+    comentarioError: 'Error al enviar el comentario',
+    fotosProgresoExito: 'Fotos de progreso agregadas correctamente',
+    fotosProgresoError: 'Error al agregar las fotos de progreso: ',
+    
+    // VALIDATIONS
+    urlInvalida: 'Por favor ingresa una URL válida',
+    maxFotos: 'Máximo 8 fotos permitidas'
 };
   

--- a/src/app/paginas/encargado-donacion/encargado-donacion.component.html
+++ b/src/app/paginas/encargado-donacion/encargado-donacion.component.html
@@ -1,6 +1,6 @@
 <div class="encargado-container">
   <div class="header">
-    <h1>Donaciones Recibidas</h1>
+    <h1>{{ texts.donacionesRecibidas }}</h1>
   </div>
 
   <div class="donaciones-list">
@@ -13,16 +13,16 @@
   
         <div class="donacion-body">
           <div class="info">
-            <p><strong>Padrino:</strong> {{ donacion.padrino?.nombre }}</p>
-            <p><strong>Necesidades:</strong> {{ donacion.necesidadesSeleccionadas || 'N/A' }}</p>
+            <p><strong>{{ texts.padrino }}</strong> {{ donacion.padrino?.nombre }}</p>
+            <p><strong>{{ texts.necesidades }}</strong> {{ donacion.necesidadesSeleccionadas || 'N/A' }}</p>
             
             <div *ngIf="donacion.fotoDonacion" class="foto-comprobante">
-              <strong>Foto comprobante:</strong>
+              <strong>{{ texts.fotoComprobante }}</strong>
               <img [src]="donacion.fotoDonacion" alt="Foto comprobante" class="foto-preview">
             </div>
             
             <div *ngIf="donacion.fotosProgreso?.length > 0" class="fotos-progreso-container">
-              <strong>Fotos de progreso:</strong>
+              <strong>{{ texts.fotosProgreso }}</strong>
               <div class="fotos-grid">
                 <div *ngFor="let foto of donacion.fotosProgreso" class="foto-item">
                   <img [src]="foto" alt="Foto de progreso" class="foto-preview">
@@ -37,18 +37,18 @@
               [class.btn-comentar]="!donacion.comentarioEncargado"
               [class.btn-comentado]="donacion.comentarioEncargado"
               [disabled]="donacion.comentarioEncargado">
-              {{ donacion.comentarioEncargado ? 'Comentario enviado' : 'Agregar Comentario' }}
+              {{ donacion.comentarioEncargado ? texts.comentarioEnviado : texts.agregarComentario }}
             </button>
   
             <button (click)="mostrarFormularioFoto(donacion.id)" 
               [class.btn-foto]="!donacion.fotoDonacion"
               [class.btn-agregado]="donacion.fotoDonacion"
               [disabled]="donacion.fotoDonacion">
-              {{ donacion.fotoDonacion ? 'Foto Comprobante enviada' : 'Agregar Foto Comprobante' }}
+              {{ donacion.fotoDonacion ? texts.fotoComprobanteEnviada : texts.agregarFotoComprobante }}
             </button>
             
             <button (click)="mostrarFormularioFotosProgreso(donacion.id)" class="btn-foto-progreso">
-              Agregar Fotos Progreso
+              {{ texts.agregarFotosProgreso }}
             </button>
           </div>
         </div>
@@ -57,25 +57,25 @@
     
 
     <ng-template #noDonaciones>
-      <p>No hay donaciones registradas.</p>
+      <p>{{ texts.noDonaciones }}</p>
     </ng-template>
 
   </div>
 
   <div *ngIf="mostrarFormulario" class="modal">
     <div class="modal-content">
-      <h3>Agregar Comentario</h3>
+      <h3>{{ texts.modalAgregarComentario }}</h3>
       <textarea [(ngModel)]="nuevoComentario" placeholder="Escribe tu comentario..."></textarea>
       <div class="modal-actions">
-        <button (click)="cancelarComentario()" class="btn-cancelar">Cancelar</button>
-        <button (click)="enviarComentario()" class="btn-enviar">Enviar</button>
+        <button (click)="cancelarComentario()" class="btn-cancelar">{{ texts.cancelar }}</button>
+        <button (click)="enviarComentario()" class="btn-enviar">{{ texts.enviar }}</button>
       </div>
     </div>
   </div>
 
   <div *ngIf="mostrarFormFoto" class="modal">
     <div class="modal-content">
-      <h3>Agregar Foto Comprobante</h3>
+      <h3>{{ texts.modalAgregarFoto }}</h3>
       <input type="text" [(ngModel)]="nuevaFotoUrl" placeholder="Ingresa la URL de la foto...">
       <div class="modal-actions">
         <button (click)="cancelarFoto()" class="btn-cancelar">Cancelar</button>
@@ -86,14 +86,14 @@
 
   <div *ngIf="mostrarFormFotosProgreso" class="modal">
     <div class="modal-content">
-      <h3>Agregar Fotos de Progreso</h3>
+      <h3>{{ texts.modalAgregarFotosProgreso }}</h3>
       <div *ngIf="fotosProgresoTemp.length < 8">
         <input type="text" [(ngModel)]="nuevaFotoProgresoUrl" placeholder="Ingresa la URL de la foto..." (keyup.enter)="agregarFotoTemp()">
         <button (click)="agregarFotoTemp()" class="btn-agregar">Agregar</button>
       </div>
       
       <div *ngIf="fotosProgresoTemp.length > 0" class="fotos-temp-container">
-        <h4>Fotos a enviar ({{fotosProgresoTemp.length}}/8):</h4>
+        <h4>{{ texts.fotosAEnviar }} ({{fotosProgresoTemp.length}}/8):</h4>
         <div class="fotos-grid">
           <div *ngFor="let foto of fotosProgresoTemp; let i = index" class="foto-item">
             <img [src]="foto" alt="Foto de progreso" class="foto-preview">
@@ -103,12 +103,12 @@
       </div>
       
       <div *ngIf="fotosProgresoTemp.length >= 8" class="max-fotos-alert">
-        Has alcanzado el límite máximo de 8 fotos
+        {{ texts.maxFotosAlerta }}
       </div>
       
       <div class="modal-actions">
-        <button (click)="cancelarFotosProgreso()" class="btn-cancelar">Cancelar</button>
-        <button (click)="enviarFotosProgreso()" [disabled]="fotosProgresoTemp.length === 0" class="btn-enviar">Enviar Fotos</button>
+        <button (click)="cancelarFotosProgreso()" class="btn-cancelar">{{ texts.cancelar }}</button>
+        <button (click)="enviarFotosProgreso()" [disabled]="fotosProgresoTemp.length === 0" class="btn-enviar">{{ texts.enviar }}</button>
       </div>
     </div>
   </div>

--- a/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
+++ b/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
@@ -115,8 +115,10 @@ export class EncargadoDonacionComponent implements OnInit {
   }
 
   mostrarFormularioFotosProgreso(donacionId: number): void {
-    this.donacionIdParaFotosProgreso = donacionId;
-    this.fotosProgresoTemp = [];
+    this.donacionIdParaFotosProgreso = donacionId;  
+    const donacion = this.donaciones.find(d => d.id === donacionId);
+    this.fotosProgresoTemp = donacion?.fotosProgreso ? [...donacion.fotosProgreso] : [];
+  
     this.mostrarFormFotosProgreso = true;
   }
 

--- a/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
+++ b/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
@@ -3,6 +3,7 @@ import { DonacionService } from '../../servicios/donacion.service';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
+import { TEXTOS } from '../../config/constants';
 
 @Component({
   selector: 'app-encargado-donacion',
@@ -16,6 +17,7 @@ export class EncargadoDonacionComponent implements OnInit {
   mostrarFormulario = false;
   nuevoComentario = '';
   donacionSeleccionadaId: number | null = null;
+  public texts = TEXTOS;
 
   mostrarFormFoto = false;
   nuevaFotoUrl = '';
@@ -141,22 +143,22 @@ export class EncargadoDonacionComponent implements OnInit {
   }
 
   enviarFotosProgreso(): void {
-    if (this.donacionIdParaFotosProgreso && this.fotosProgresoTemp.length > 0) {
-        this.donacionService.agregarFotosProgreso(
-            this.donacionIdParaFotosProgreso,
-            this.fotosProgresoTemp 
-        ).subscribe({
-            next: () => {
-                this.cancelarFotosProgreso();
-                const encargadoId = this.route.snapshot.paramMap.get('id');
-                if (encargadoId) this.cargarDonaciones(+encargadoId);
-                alert('Fotos de progreso agregadas correctamente');
-            },
-            error: (err) => {
-                console.error('Error al agregar fotos de progreso:', err);
-                alert('Error al agregar las fotos de progreso: ' + err.error?.message || err.message);
-            }
-        });
+    if (this.donacionIdParaFotosProgreso) {
+      this.donacionService.agregarFotosProgreso(
+        this.donacionIdParaFotosProgreso,
+        this.fotosProgresoTemp
+      ).subscribe({
+        next: () => {
+          this.cancelarFotosProgreso();
+          const encargadoId = this.route.snapshot.paramMap.get('id');
+          if (encargadoId) this.cargarDonaciones(+encargadoId);
+          alert(this.texts.fotosProgresoExito);
+        },
+        error: (err) => {
+          console.error('Error al agregar fotos de progreso:', err);
+          alert(this.texts.fotosProgresoError + (err.error?.message || err.message));
+        }
+      });
     }
   }
 

--- a/src/app/servicios/donacion.service.ts
+++ b/src/app/servicios/donacion.service.ts
@@ -37,6 +37,10 @@ export class DonacionService {
   }
 
   agregarFotosProgreso(donacionId: number, fotos: string[]): Observable<any> {
-    return this.http.put(`${this.backendUrl}/${donacionId}/fotos-progreso`, fotos);
+    return this.http.put(`${this.backendUrl}/${donacionId}/fotos-progreso`, { fotos });
+  }
+  
+  actualizarFotosProgreso(donacionId: number, fotos: string[]): Observable<any> {
+    return this.http.put(`${this.backendUrl}/${donacionId}/fotos-progreso`, { fotos });
   }
 }


### PR DESCRIPTION
Se implementaron cambios en el componente encargado-donacion y en el servicio de la donacion para poder actualizar las fotos de progreso, antes se eliminaban si se deseaba agregar nuevas fotos, ahora se recuperan y se pueden descartar o mantener al agregar nuevas fotos.
![image](https://github.com/user-attachments/assets/40b534f1-9ddb-456d-839f-c4de20218283)
