### PR TITLE
Hm6 04 mejora buscador hogares

### DIFF
--- a/src/app/paginas/detalle-hogar/detalle-hogar.component.html
+++ b/src/app/paginas/detalle-hogar/detalle-hogar.component.html
@@ -32,9 +32,9 @@
     <p><strong>Cantidad de niños:</strong> {{ encargado.ninos?.length || 0 }}</p>
   </div>
   <div class="field--column-card-elements">
-    <button class="btn btn--secondary-button" (click)="agendarVisita()">Visitar</button>
-    <button class="btn btn--secondary-button" (click)="irChat()">Chat</button>
-    <button class="btn btn--primary-button" (click)="irARegistroDonacion(padrino.id, encargado.id)">Volver a Donar</button>
+    <button class="btn btn--secondary-button" [disabled]="padrino.estado == 'En revision'" (click)="agendarVisita()">Visitar</button>
+    <button class="btn btn--secondary-button" [disabled]="padrino.estado == 'En revision'" (click)="irChat()">Chat</button>
+    <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision'" (click)="irARegistroDonacion(padrino.id, encargado.id)">Volver a Donar</button>
   </div>
   <div *ngIf="encargado.ninos?.length" class="card--simple-text">
     <h3>Necesidades del hogar:</h3>

--- a/src/app/paginas/encargado-donacion/encargado-donacion.component.html
+++ b/src/app/paginas/encargado-donacion/encargado-donacion.component.html
@@ -43,22 +43,22 @@
               (click)="!donacion.comentarioEncargado && mostrarFormularioComentario(donacion.id)" 
               [class.btn-comentar]="!donacion.comentarioEncargado"
               [class.btn-comentado]="donacion.comentarioEncargado"
-              [disabled]="donacion.comentarioEncargado">
+              [disabled]="donacion.comentarioEncargado || encargado.estado == 'Suspendido'">
               {{ donacion.comentarioEncargado ? texts.comentarioEnviado : texts.agregarComentario }}
             </button>
   
             <button (click)="mostrarFormularioFoto(donacion.id)" 
               [class.btn-foto]="!donacion.fotoDonacion"
               [class.btn-agregado]="donacion.fotoDonacion"
-              [disabled]="donacion.fotoDonacion">
+              [disabled]="donacion.fotoDonacion || encargado.estado == 'Suspendido' ">
               {{ donacion.fotoDonacion ? texts.fotoComprobanteEnviada : texts.agregarFotoComprobante }}
             </button>
             
-            <button (click)="mostrarFormularioFotosProgreso(donacion.id)" class="btn-foto-progreso">
+            <button (click)="mostrarFormularioFotosProgreso(donacion.id)" [disabled]="encargado.estado == 'Suspendido' " class="btn-foto-progreso">
               {{ texts.agregarFotosProgreso }}
             </button>
 
-            <button class="btn-chat" (click)="irChat(donacion.padrino?.id)">{{texts.chat}}</button>
+            <button class="btn-chat" [disabled]="encargado.estado == 'Suspendido' || encargado.estado == 'En revision' " (click)="irChat(donacion.padrino?.id)">{{texts.chat}}</button>
           </div>
         </div>
       </div>

--- a/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
+++ b/src/app/paginas/encargado-donacion/encargado-donacion.component.ts
@@ -5,6 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
 import { TEXTOS } from '../../config/constants';
 import { UserAuthenticationService } from '../../servicios/user-authentication.service';
+import { EncargadoService } from '../../servicios/encargado.service';
 
 @Component({
   selector: 'app-encargado-donacion',
@@ -19,6 +20,7 @@ export class EncargadoDonacionComponent implements OnInit {
   mostrarFormulario = false;
   nuevoComentario = '';
   donacionSeleccionadaId: number | null = null;
+  encargado: any  = null;
     
   mostrarFormFoto = false;
   nuevaFotoUrl = '';
@@ -33,7 +35,8 @@ export class EncargadoDonacionComponent implements OnInit {
     private donacionService: DonacionService,
     private route: ActivatedRoute,
     private router: Router,
-    private authService: UserAuthenticationService
+    private authService: UserAuthenticationService,
+    private encargadoService: EncargadoService
   ) {}
 
   ngOnInit(): void {
@@ -53,6 +56,14 @@ export class EncargadoDonacionComponent implements OnInit {
     this.donacionService.getDonacionesByEncargado(encargadoId).subscribe({
       next: (data) => {
         this.donaciones = data;
+        this.encargadoService.getEncargadoById(encargadoId).subscribe({
+          next:(data) => {
+            this.encargado = data;
+          },
+          error:(err)=>{
+            console.error('Error al cargar encargado:', err);
+          }
+        })
       },
       error: (err) => {
         console.error('Error al cargar donaciones:', err);

--- a/src/app/paginas/home-padrino/home-padrino.component.html
+++ b/src/app/paginas/home-padrino/home-padrino.component.html
@@ -48,7 +48,7 @@
             <hr>
             <div class="field--column-card-elements amount-block">
               <p>${{ donacion.cantidadDonacion |  number:'1.2-2' }}</p>
-              <button class="btn btn--primary-button" (click)="irARegistroDonacion(padrino.id, donacion.encargado.id)">Volver a Donar</button>
+              <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision'" (click)="irARegistroDonacion(padrino.id, donacion.encargado.id)">Volver a Donar</button>
             </div>
           </div>
           
@@ -86,8 +86,8 @@
     
               <p><strong>Niños: </strong> {{ encargado.ninos?.length || 0 }}</p>
               <div class="field--row-card-elements">
-                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(encargado.id)" (click)="verHogar(encargado.id)">Ver Hogar</button>
-                <button class="btn btn--primary-button" (click)="irARegistroDonacion(padrino.id, encargado.id)">Donar</button>
+                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(encargado.id) || padrino.estado == 'En revision'" (click)="verHogar(encargado.id)">Ver Hogar</button>
+                <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision'" (click)="irARegistroDonacion(padrino.id, encargado.id)">Donar</button>
               </div>
             </div>
           </div>

--- a/src/app/paginas/home-padrino/home-padrino.component.html
+++ b/src/app/paginas/home-padrino/home-padrino.component.html
@@ -42,13 +42,13 @@
               </div>
               <div class="field--row-card-elements">
                 <button class="btn btn--secondary-button" (click)="abrirDetallesDialogo(donacion.id)">Ver detalles</button>
-                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(donacion.encargado.id)" (click)="verHogar(donacion.encargado.id)">Ver Hogar</button>
+                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(donacion.encargado.id) || padrino.estado == 'Suspendido'" (click)="verHogar(donacion.encargado.id)">Ver Hogar</button>
               </div>
             </div>
             <hr>
             <div class="field--column-card-elements amount-block">
               <p>${{ donacion.cantidadDonacion |  number:'1.2-2' }}</p>
-              <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision'" (click)="irARegistroDonacion(padrino.id, donacion.encargado.id)">Volver a Donar</button>
+              <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision' || padrino.estado == 'Suspendido'" (click)="irARegistroDonacion(padrino.id, donacion.encargado.id)">Volver a Donar</button>
             </div>
           </div>
           
@@ -86,8 +86,8 @@
     
               <p><strong>Niños: </strong> {{ encargado.ninos?.length || 0 }}</p>
               <div class="field--row-card-elements">
-                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(encargado.id) || padrino.estado == 'En revision'" (click)="verHogar(encargado.id)">Ver Hogar</button>
-                <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision'" (click)="irARegistroDonacion(padrino.id, encargado.id)">Donar</button>
+                <button class="btn btn--secondary-button" [disabled]="!haDonadoA(encargado.id) || padrino.estado == 'En revision' || padrino.estado == 'Suspendido'" (click)="verHogar(encargado.id)">Ver Hogar</button>
+                <button class="btn btn--primary-button" [disabled]="padrino.estado == 'En revision' || padrino.estado == 'Suspendido'" (click)="irARegistroDonacion(padrino.id, encargado.id)">Donar</button>
               </div>
             </div>
           </div>

--- a/src/app/paginas/home-padrino/home-padrino.component.ts
+++ b/src/app/paginas/home-padrino/home-padrino.component.ts
@@ -150,10 +150,12 @@ export class HomePadrinoComponent implements OnInit {
       return this.encargadosAprobados;
     }
 
-    const texto = this.busqueda.toLowerCase();
-    return this.encargadosAprobados.filter(encargado =>
-      encargado.nombre_hogar.toLowerCase().startsWith(texto)
-    );
+    const palabrasBusqueda = this.busqueda.toLowerCase().split(/\s+/);
+
+    return this.encargadosAprobados.filter(encargado => {
+      const nombreHogar = encargado.nombre_hogar.toLowerCase();
+      return palabrasBusqueda.some(palabra => nombreHogar.includes(palabra));
+    });
   }
 
   irAdministradores(): void{

--- a/src/app/paginas/login/login.component.ts
+++ b/src/app/paginas/login/login.component.ts
@@ -96,7 +96,9 @@ export class LoginComponent {
     }
 
     if(estado === 'Suspendido'){
-      alert("Su cuenta se encuentra SUSPENDIDA, por favor contáctese con Soporte Técnico.");
+      if(this.padrino){
+        alert("Su cuenta se encuentra SUSPENDIDA.\n No puede:\n DONAR, CHATEAR, AGENDAR VISITA, VOLVER A DONAR o VER a NINGUN HOGAR.\n Por favor contáctese con Soporte Técnico.");
+      }
     }
   }
   cancelLogin() {

--- a/src/app/paginas/login/login.component.ts
+++ b/src/app/paginas/login/login.component.ts
@@ -93,11 +93,17 @@ export class LoginComponent {
       if(this.padrino){
         alert("Su cuenta se encuentra EN REVISIÓN.\n No puede:\n DONAR, CHATEAR, AGENDAR VISITA o VOLVER A DONAR a NINGUN HOGAR.\n Por favor contáctese con Soporte Técnico.");
       }
+      if(this.encargado){
+        alert("Su cuenta se encuentra EN REVISIÓN.\n No puede:\n RECIBIR DONACIONES, CHATEAR CON PADRINOS ni REGISTRAR NUEVOS NIÑOS.\n Por favor contáctese con Soporte Técnico.");
+      }
     }
 
     if(estado === 'Suspendido'){
       if(this.padrino){
         alert("Su cuenta se encuentra SUSPENDIDA.\n No puede:\n DONAR, CHATEAR, AGENDAR VISITA, VOLVER A DONAR o VER a NINGUN HOGAR.\n Por favor contáctese con Soporte Técnico.");
+      }
+      if(this.encargado){
+        alert("Su cuenta se encuentra SUSPENDIDA.\n No puede:\n RECIBIR DONACIONES, CHATEAR CON PADRINOS, REGISTRAR, EDITAR o ELIMINAR NIÑOS, ENVIAR COMENTARIOS ni SUBIR FOTOS de las DONACIONES.\n Por favor contáctese con Soporte Técnico.");
       }
     }
   }

--- a/src/app/paginas/login/login.component.ts
+++ b/src/app/paginas/login/login.component.ts
@@ -90,7 +90,9 @@ export class LoginComponent {
 
   mensajes(estado:any):void{
     if(estado === 'En revision'){
-      alert("Su cuenta se encuentra EN REVISIÓN, por favor contáctese con Soporte Técnico.");
+      if(this.padrino){
+        alert("Su cuenta se encuentra EN REVISIÓN.\n No puede:\n DONAR, CHATEAR, AGENDAR VISITA o VOLVER A DONAR a NINGUN HOGAR.\n Por favor contáctese con Soporte Técnico.");
+      }
     }
 
     if(estado === 'Suspendido'){

--- a/src/app/paginas/ninos-hogar/ninos-hogar.component.html
+++ b/src/app/paginas/ninos-hogar/ninos-hogar.component.html
@@ -28,8 +28,8 @@
                 </ul>
               </div>
               <div class="nino-buttons">
-                <button class="btn-editar-nino" (click)="editarNino(nino.id)">Editar Datos</button>
-                <button class="btn-eliminar-nino" (click)="eliminarNino(nino.id)">
+                <button class="btn-editar-nino" [disabled]="encargado.estado == 'Suspendido'" (click)="editarNino(nino.id)">Editar Datos</button>
+                <button class="btn-eliminar-nino" [disabled]="encargado.estado == 'Suspendido'" (click)="eliminarNino(nino.id)">
                   <i class="fas fa-trash-alt"></i> Eliminar
                 </button>
               </div>

--- a/src/app/paginas/ninos-hogar/ninos-hogar.component.html
+++ b/src/app/paginas/ninos-hogar/ninos-hogar.component.html
@@ -10,7 +10,7 @@
   <div class="perfil-content">
     <h1 style="color: #e65c4f;">Niños del Hogar</h1>
     <div class="boton-container">
-      <button class="btn-crear-nino" (click)="irCrearNino()">Crear Niño</button>
+      <button class="btn-crear-nino" [disabled]="encargado.estado == 'En revision' || encargado.estado == 'Suspendido'" (click)="irCrearNino()">Crear Niño</button>
     </div>
 
     <div class="ninos-del-hogar">


### PR DESCRIPTION
Se mejoro el buscador, ahora no busca segun el inicio del nombre del hogar, sino por palabras clave o coincindencias dentro del nombre del hogar:
![image](https://github.com/user-attachments/assets/4fe531b9-4937-48b8-9a2b-4bb46826ee4d)

Se agregaron las siguientes restricciones (botones desabilitados) a los padrinos EN REVISION:
![image](https://github.com/user-attachments/assets/de819c95-caac-43f4-b265-15b0ce06f247)

Se agregaron las siguientes restricciones (botones desabilitados) a los padrinos SUSPENDIDOS:
![image](https://github.com/user-attachments/assets/7f66d701-7741-4d22-a2f7-fdb2b28611a4)

Se agregaron las siguientes restricciones (botones desabilitados) a los encargados EN REVISION:
![image](https://github.com/user-attachments/assets/36fd6af5-a634-4cb8-a49e-88b191b97549)

Se agregaron las siguientes restricciones (botones desabilitados) a los encargados SUSPENDIDOS:
![image](https://github.com/user-attachments/assets/09780445-5dec-4374-a2d8-d4144f4e1733)

